### PR TITLE
fix: sed failed on linux

### DIFF
--- a/cli/command/init.go
+++ b/cli/command/init.go
@@ -21,8 +21,8 @@ set -x
 git clone git@github.com:payfazz/tango.git $1
 cd $1
 mv cmd/tango cmd/$1
-find .ci cmd config database http internal lib test -type f -exec sed -i '' "s/tango/$1/g" {} \;
-sed -i '' "s/tango/$1/g" go.mod
+find .ci cmd config database http internal lib test -type f -exec sed -i'' "s/tango/$1/g" {} \;
+sed -i'' "s/tango/$1/g" go.mod
 go mod tidy
 rm -rf cli cli.go .git
 cd ..`


### PR DESCRIPTION
see: https://stackoverflow.com/a/4247319
sed command fail on linux because there is space between `-i` and `''`
this change will make it compatible with linux and OS X 10.9+