### PR TITLE
enhancement: make PrintEnv use io.Writer

### DIFF
--- a/template/default/cmd/config/main.go
+++ b/template/default/cmd/config/main.go
@@ -1,7 +1,13 @@
 package main
 
-import "github.com/payfazz/tango/template/default/config"
+import (
+	"github.com/payfazz/tango/template/default/config"
+	"log"
+	"os"
+)
 
 func main() {
-	config.PrintEnv()
+	if err := config.PrintEnv(os.Stdout); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/template/default/config/func.go
+++ b/template/default/config/func.go
@@ -122,7 +122,8 @@ func mergeConfigInterface(configInterfaces ...map[string]interface{}) map[string
 	return result
 }
 
-func PrintEnv() {
+// PrintEnv prints environment variables sorted by key in ascending order.
+func PrintEnv(w io.Writer) error {
 	keys := make([]string, 0)
 	for key, _ := range base {
 		keys = append(keys, key)
@@ -131,6 +132,9 @@ func PrintEnv() {
 
 	for _, key := range keys {
 		val := base[key]
-		fmt.Printf("%s: \"%s\"\n", key, val)
+		if _, err := w.Write([]byte(fmt.Sprintf("%s: \"%s\"\n", key, val))); err != nil {
+			return err
+		}
 	}
+	return nil
 }


### PR DESCRIPTION
Add comment for PrintEnv() (which is recommended for exported function), and change its implementation to write to io.Writer instead of directly using fmt.Printf() (Easier to mock and test).

Signed-off-by: Zasda Yusuf Mikail <zasdaym@gmail.com>